### PR TITLE
chore: disable the dialogues module.

### DIFF
--- a/Server/Program.cs
+++ b/Server/Program.cs
@@ -20,7 +20,6 @@ RegisterTypeFromConfiguration(
 
 builder.Services
     .AddAccountManagementModule()
-    .AddDialogManagementModule(builder.Configuration.GetConnectionString("RedisDialogue")!)
     .AddNonPlayerCharacterModule(
         builder.Configuration.GetConnectionString("NonPlayerCharacterDbContext")!
     );


### PR DESCRIPTION
it's not used for now, and it's getting a bit tedious having to constantly launch the docker script only for the redis requirement.

i've disabled it, but one of the ideas thrown around during the group meetings was to temporarily swap out redis for IMemoryCache

if the other option is more preferable right now, i can redo this commit.