### PR TITLE
fix: item's background color is now consistent

### DIFF
--- a/Server/Components/UI/ItemCard.razor
+++ b/Server/Components/UI/ItemCard.razor
@@ -1,12 +1,12 @@
 @using Fracture.Server.Modules.Items.Models
 
 <div class="col">
-    <div class="card" style="width: 15rem;">
-        <div class="card-header" style="background-color: var(@_color)">
+    <div class="card" style="min-width: 13rem;">
+        <div class="card-header" style="background-color: var(--rarity-@Item.Rarity.ToString().ToLower())">
             @Item.Name
         </div>
         <div class="card-body">
-            <button class="btn btn-primary" @onmouseover="ShowItemHistoryAsync" @onmouseleave="HideItemHistoryAsync" data-bs-toggle="collapse" data-bs-target="#collapse-@guid">Item History </button>
+            <button class="btn btn-primary mb-3" @onmouseover="ShowItemHistoryAsync" @onmouseleave="HideItemHistoryAsync" data-bs-toggle="collapse" data-bs-target="#collapse-@guid">Item History </button>
             <div class="collapse" id="collapse-@guid">
                 <p class="card-text">@Item.History</p>
             </div>
@@ -42,26 +42,4 @@
     [Parameter] public bool ItemHistory { get; set; }
     [Parameter] public EventCallback OnEquipClicked { get; set; }
     [Parameter] public EventCallback OnUnequipClicked { get; set; }
-
-    private string _color = "--rarity-common";
-
-    protected override void OnInitialized()
-    {
-        ChangeColor();
-        base.OnInitialized();
-    }
-
-    private void ChangeColor()
-    {
-        _color = Item.Rarity switch
-        {
-            ItemRarity.Common => "--rarity-common",
-            ItemRarity.Uncommon => "--rarity-uncommon",
-            ItemRarity.Rare => "--rarity-rare",
-            ItemRarity.Insane => "--rarity-insane",
-            ItemRarity.Epic => "--rarity-epic",
-            ItemRarity.Legendary => "--rarity-legendary",
-            _ => _color
-        };
-    }
 }

--- a/Server/Components/UI/ItemCard.razor
+++ b/Server/Components/UI/ItemCard.razor
@@ -1,8 +1,9 @@
 @using Fracture.Server.Modules.Items.Models
+@using Fracture.Server.EnumExtensions
 
 <div class="col">
     <div class="card" style="min-width: 13rem;">
-        <div class="card-header" style="background-color: var(--rarity-@Item.Rarity.ToString().ToLower())">
+        <div class="card-header" style="background-color: var(@Item.Rarity.ToCssClassName())">
             @Item.Name
         </div>
         <div class="card-body">

--- a/Server/Modules/Items/Models/ItemRarity.cs
+++ b/Server/Modules/Items/Models/ItemRarity.cs
@@ -12,3 +12,30 @@ namespace Fracture.Server.Modules.Items.Models
         Legendary
     }
 }
+
+namespace Fracture.Server.EnumExtensions
+{
+    using Fracture.Server.Modules.Items.Models;
+
+    public static class ItemRarityExtensions
+    {
+        public static string ToCssClassName(this ItemRarity rarity)
+        {
+            return rarity switch
+            {
+                ItemRarity.Common => "--rarity-common",
+                ItemRarity.Uncommon => "--rarity-uncommon",
+                ItemRarity.Rare => "--rarity-rare",
+                ItemRarity.Insane => "--rarity-insane",
+                ItemRarity.Epic => "--rarity-epic",
+                ItemRarity.Legendary => "--rarity-legendary",
+                _
+                    => throw new ArgumentOutOfRangeException(
+                        nameof(rarity),
+                        rarity,
+                        $"Rarity '{rarity}' does not have a corresponding CSS class."
+                    )
+            };
+        }
+    }
+}


### PR DESCRIPTION
Changing the color only occured when the card was created, but it didn't change when the inventory/equipment's state changed. By binding the color to the item's rarity directly, we avoid that issue (thankfully the CSS variable names match the rarity names).
It doesn't look as clean as I'd like it to, but it gets the job done.
 I also added a little bit of a bottom margin to the Item History button, so it looks nicer and set min-width of the card to 13rem, which looks fine on 1080p screens - it probably isn't a perfect solution.