### PR TITLE
Saving player postion on quit

### DIFF
--- a/Server/Components/Pages/GamePage.razor
+++ b/Server/Components/Pages/GamePage.razor
@@ -153,3 +153,10 @@
 		</div>
 	</div>
 </div>
+
+@code {
+	private async Task Logout()
+	{
+		await LogoutAsync();
+	}
+}

--- a/Server/Components/Pages/GamePage.razor.cs
+++ b/Server/Components/Pages/GamePage.razor.cs
@@ -18,9 +18,9 @@ public partial class GamePage : IAsyncDisposable
     private List<IPathfindingNode>? Path { get; set; }
     private CancellationTokenSource _autosaveCts = null!;
 
-    // Zmienne do debounce'a i auto-save'a
-    private int _lastSavedX = -1;
-    private int _lastSavedY = -1; // 3 sekundy
+    // Zmienne do auto-save'a
+    private int _lastSavedX;
+    private int _lastSavedY;
     private const int AUTOSAVE_INTERVAL_MS = 120000; // 2 minuty
 
     protected override async Task OnInitializedAsync()

--- a/Server/Components/Pages/GamePage.razor.cs
+++ b/Server/Components/Pages/GamePage.razor.cs
@@ -9,7 +9,7 @@ using Fracture.Server.Modules.Users.Services;
 
 namespace Fracture.Server.Components.Pages;
 
-public partial class GamePage
+public partial class GamePage : IAsyncDisposable
 {
     private Dictionary<string, object> _mapPopupParameters = null!;
 
@@ -33,6 +33,12 @@ public partial class GamePage
         {
             await MovementService.InitializeAsync();
             BackgroundImage = GetBackgroundImagePath();
+
+            // Załaduj zapisaną pozycję gracza (jeśli istnieje)
+            if (UserService.User != null)
+            {
+                await LoadPlayerPositionAsync();
+            }
         }
 
         MovementService.OnMapEntered += async (sender, args) =>
@@ -110,10 +116,56 @@ public partial class GamePage
         return true;
     }
 
-    private void Logout()
+    private async Task LoadPlayerPositionAsync()
     {
+        if (UserService.User == null)
+            return;
+
+        var positionString = await UserService.GetPlayerPositionAsync(UserService.User.Id);
+
+        if (string.IsNullOrEmpty(positionString))
+            return;
+
+        var parts = positionString.Split(',');
+        if (
+            parts.Length == 2
+            && int.TryParse(parts[0], out int x)
+            && int.TryParse(parts[1], out int y)
+        )
+        {
+            if (MovementService.CanMove(x, y))
+            {
+                MovementService.CurrentX = x;
+                MovementService.CurrentY = y;
+                Logger.LogInformation($"Loaded player position: ({x}, {y})");
+            }
+        }
+    }
+
+    private async Task SavePlayerPositionAsync()
+    {
+        if (UserService.User != null && MovementService.CurrentMap != null)
+        {
+            var position = $"{MovementService.CurrentX},{MovementService.CurrentY}";
+            await UserService.UpdatePlayerPositionAsync(UserService.User.Id, position);
+            Logger.LogInformation($"Saved player position: {position}");
+        }
+    }
+
+    private async Task LogoutAsync()
+    {
+        // Zapisz pozycję przed wylogowaniem
+        await SavePlayerPositionAsync();
+
+        await ProtectedSessionStore.DeleteAsync("username");
         NavigationManager.NavigateTo("/home");
-        ProtectedSessionStore.DeleteAsync("username");
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        // Zapisz pozycję gdy gracz zamknie przeglądarkę
+        await SavePlayerPositionAsync();
+        GC.SuppressFinalize(this);
     }
 
     private string GetBackgroundImagePath()

--- a/Server/Components/Pages/GamePage.razor.cs
+++ b/Server/Components/Pages/GamePage.razor.cs
@@ -1,6 +1,5 @@
 using Fracture.Server.Components.Popups;
 using Fracture.Server.Components.UI;
-using Fracture.Server.Modules.Items.Models;
 using Fracture.Server.Modules.MapGenerator.Models.Map;
 using Fracture.Server.Modules.MapGenerator.UI.Models;
 using Fracture.Server.Modules.Pathfinding.Models;
@@ -16,12 +15,6 @@ public partial class GamePage : IAsyncDisposable
     public string BackgroundImage { get; set; } = string.Empty;
     private readonly MapDisplayOptions _mapDisplayOptions = new();
     private List<IPathfindingNode>? Path { get; set; }
-    private CancellationTokenSource _autosaveCts = null!;
-
-    // Zmienne do auto-save'a
-    private int _lastSavedX;
-    private int _lastSavedY;
-    private const int AUTOSAVE_INTERVAL_MS = 120000; // 2 minuty
 
     protected override async Task OnInitializedAsync()
     {
@@ -35,12 +28,12 @@ public partial class GamePage : IAsyncDisposable
         {
             await MovementService.InitializeAsync();
             BackgroundImage = GetBackgroundImagePath();
-
-            // Załaduj zapisaną pozycję gracza (jeśli istnieje)
-            if (UserService.User != null)
-            {
-                await LoadPlayerPositionAsync();
-            }
+        }
+        else
+        {
+            //Reset dla nowego gracza
+            await MovementService.ReloadPlayerPositionAsync();
+            BackgroundImage = GetBackgroundImagePath();
         }
 
         MovementService.OnMapEntered += async (sender, args) =>
@@ -90,9 +83,8 @@ public partial class GamePage : IAsyncDisposable
         {
             { "MapDisplayData", _mapDisplayOptions },
         };
-
-        _autosaveCts = new CancellationTokenSource();
-        _ = AutosavePositionAsync(_autosaveCts.Token);
+        //Autosave Pozycji Gracza
+        MovementService.StartAutosave();
 
         await base.OnInitializedAsync();
     }
@@ -121,113 +113,17 @@ public partial class GamePage : IAsyncDisposable
         return true;
     }
 
-    private async Task LoadPlayerPositionAsync()
-    {
-        if (UserService.User == null || MovementService.CurrentMap == null)
-            return;
-
-        var positionString = await UserService.GetPlayerPositionAsync(UserService.User.Id);
-
-        if (string.IsNullOrEmpty(positionString))
-            return;
-
-        var parts = positionString.Split(',');
-        if (
-            parts.Length == 2
-            && int.TryParse(parts[0], out int x)
-            && int.TryParse(parts[1], out int y)
-        )
-        {
-            if (MovementService.CanMove(x, y))
-            {
-                // Pozycja jest walkable - załaduj bez problemu
-                MovementService.CurrentX = x;
-                MovementService.CurrentY = y;
-                _lastSavedX = x;
-                _lastSavedY = y;
-                Logger.LogInformation($"Loaded player position: ({x}, {y})");
-            }
-            else
-            {
-                // Pozycja nie jest walkable - losuj nową i od razu zapisz do bazy
-                var randomPos = MovementService.CurrentMap.GetRandomWalkableNode();
-                MovementService.CurrentX = randomPos.X;
-                MovementService.CurrentY = randomPos.Y;
-                _lastSavedX = randomPos.X;
-                _lastSavedY = randomPos.Y;
-
-                // Natychmiast zapisz nową pozycję do bazy
-                await SavePlayerPositionAsync();
-
-                Logger.LogWarning(
-                    $"Saved position ({x}, {y}) is not walkable on current map. Spawned at random position: ({randomPos.X}, {randomPos.Y}) - position saved immediately"
-                );
-            }
-        }
-    }
-
-    private async Task SavePlayerPositionAsync()
-    {
-        if (UserService.User != null && MovementService.CurrentMap != null)
-        {
-            var position = $"{MovementService.CurrentX},{MovementService.CurrentY}";
-            await UserService.UpdatePlayerPositionAsync(UserService.User.Id, position);
-            Logger.LogInformation($"Saved player position: {position}");
-        }
-    }
-
-    private async Task AutosavePositionAsync(CancellationToken cancellationToken)
-    {
-        while (!cancellationToken.IsCancellationRequested)
-        {
-            try
-            {
-                await Task.Delay(AUTOSAVE_INTERVAL_MS, cancellationToken); // Co 2 minuty
-
-                // Zapisz tylko jeśli pozycja się zmieniła
-                if (
-                    MovementService.CurrentX != _lastSavedX
-                    || MovementService.CurrentY != _lastSavedY
-                )
-                {
-                    await SavePlayerPositionAsync();
-                    _lastSavedX = MovementService.CurrentX;
-                    _lastSavedY = MovementService.CurrentY;
-                    Logger.LogInformation(
-                        $"Autosave triggered - position changed: ({_lastSavedX}, {_lastSavedY})"
-                    );
-                }
-                else
-                {
-                    Logger.LogInformation("Autosave skipped - position unchanged");
-                }
-            }
-            catch (OperationCanceledException)
-            {
-                break;
-            }
-            catch (Exception ex)
-            {
-                Logger.LogError(ex, "Error during autosave");
-            }
-        }
-    }
-
     private async Task LogoutAsync()
     {
-        await SavePlayerPositionAsync();
-
+        await MovementService.SavePlayerPositionAsync();
         await ProtectedSessionStore.DeleteAsync("username");
         NavigationManager.NavigateTo("/home");
     }
 
     public async ValueTask DisposeAsync()
     {
-        _autosaveCts?.Cancel();
-        _autosaveCts?.Dispose();
-
-        await SavePlayerPositionAsync();
-
+        MovementService.StopAutosave();
+        await MovementService.SavePlayerPositionAsync();
         GC.SuppressFinalize(this);
     }
 

--- a/Server/Components/Pages/GamePage.razor.cs
+++ b/Server/Components/Pages/GamePage.razor.cs
@@ -12,14 +12,16 @@ namespace Fracture.Server.Components.Pages;
 public partial class GamePage : IAsyncDisposable
 {
     private Dictionary<string, object> _mapPopupParameters = null!;
-
     private PopupContainer _popup = null!;
-
     public string BackgroundImage { get; set; } = string.Empty;
-
     private readonly MapDisplayOptions _mapDisplayOptions = new();
-
     private List<IPathfindingNode>? Path { get; set; }
+    private CancellationTokenSource _autosaveCts = null!;
+
+    // Zmienne do debounce'a i auto-save'a
+    private int _lastSavedX = -1;
+    private int _lastSavedY = -1; // 3 sekundy
+    private const int AUTOSAVE_INTERVAL_MS = 120000; // 2 minuty
 
     protected override async Task OnInitializedAsync()
     {
@@ -89,6 +91,9 @@ public partial class GamePage : IAsyncDisposable
             { "MapDisplayData", _mapDisplayOptions },
         };
 
+        _autosaveCts = new CancellationTokenSource();
+        _ = AutosavePositionAsync(_autosaveCts.Token);
+
         await base.OnInitializedAsync();
     }
 
@@ -133,22 +138,29 @@ public partial class GamePage : IAsyncDisposable
             && int.TryParse(parts[1], out int y)
         )
         {
-            // Sprawdzenie czy pozycja jest walkable na aktualnej mapie
             if (MovementService.CanMove(x, y))
             {
+                // Pozycja jest walkable - załaduj bez problemu
                 MovementService.CurrentX = x;
                 MovementService.CurrentY = y;
+                _lastSavedX = x;
+                _lastSavedY = y;
                 Logger.LogInformation($"Loaded player position: ({x}, {y})");
             }
             else
             {
-                // Pozycja nie jest walkable, losujemy nową
+                // Pozycja nie jest walkable - losuj nową i od razu zapisz do bazy
                 var randomPos = MovementService.CurrentMap.GetRandomWalkableNode();
                 MovementService.CurrentX = randomPos.X;
                 MovementService.CurrentY = randomPos.Y;
+                _lastSavedX = randomPos.X;
+                _lastSavedY = randomPos.Y;
+
+                // Natychmiast zapisz nową pozycję do bazy
                 await SavePlayerPositionAsync();
+
                 Logger.LogWarning(
-                    $"Saved position ({x}, {y}) is not walkable on current map. Spawned at random position: ({randomPos.X}, {randomPos.Y})"
+                    $"Saved position ({x}, {y}) is not walkable on current map. Spawned at random position: ({randomPos.X}, {randomPos.Y}) - position saved immediately"
                 );
             }
         }
@@ -164,9 +176,45 @@ public partial class GamePage : IAsyncDisposable
         }
     }
 
+    private async Task AutosavePositionAsync(CancellationToken cancellationToken)
+    {
+        while (!cancellationToken.IsCancellationRequested)
+        {
+            try
+            {
+                await Task.Delay(AUTOSAVE_INTERVAL_MS, cancellationToken); // Co 2 minuty
+
+                // Zapisz tylko jeśli pozycja się zmieniła
+                if (
+                    MovementService.CurrentX != _lastSavedX
+                    || MovementService.CurrentY != _lastSavedY
+                )
+                {
+                    await SavePlayerPositionAsync();
+                    _lastSavedX = MovementService.CurrentX;
+                    _lastSavedY = MovementService.CurrentY;
+                    Logger.LogInformation(
+                        $"Autosave triggered - position changed: ({_lastSavedX}, {_lastSavedY})"
+                    );
+                }
+                else
+                {
+                    Logger.LogInformation("Autosave skipped - position unchanged");
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                break;
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError(ex, "Error during autosave");
+            }
+        }
+    }
+
     private async Task LogoutAsync()
     {
-        // Zapisz pozycję przed wylogowaniem
         await SavePlayerPositionAsync();
 
         await ProtectedSessionStore.DeleteAsync("username");
@@ -175,8 +223,11 @@ public partial class GamePage : IAsyncDisposable
 
     public async ValueTask DisposeAsync()
     {
-        // Zapisz pozycję gdy gracz zamknie przeglądarkę
+        _autosaveCts?.Cancel();
+        _autosaveCts?.Dispose();
+
         await SavePlayerPositionAsync();
+
         GC.SuppressFinalize(this);
     }
 

--- a/Server/Components/Pages/GamePage.razor.cs
+++ b/Server/Components/Pages/GamePage.razor.cs
@@ -118,7 +118,7 @@ public partial class GamePage : IAsyncDisposable
 
     private async Task LoadPlayerPositionAsync()
     {
-        if (UserService.User == null)
+        if (UserService.User == null || MovementService.CurrentMap == null)
             return;
 
         var positionString = await UserService.GetPlayerPositionAsync(UserService.User.Id);
@@ -133,11 +133,23 @@ public partial class GamePage : IAsyncDisposable
             && int.TryParse(parts[1], out int y)
         )
         {
+            // Sprawdzenie czy pozycja jest walkable na aktualnej mapie
             if (MovementService.CanMove(x, y))
             {
                 MovementService.CurrentX = x;
                 MovementService.CurrentY = y;
                 Logger.LogInformation($"Loaded player position: ({x}, {y})");
+            }
+            else
+            {
+                // Pozycja nie jest walkable, losujemy nową
+                var randomPos = MovementService.CurrentMap.GetRandomWalkableNode();
+                MovementService.CurrentX = randomPos.X;
+                MovementService.CurrentY = randomPos.Y;
+                await SavePlayerPositionAsync();
+                Logger.LogWarning(
+                    $"Saved position ({x}, {y}) is not walkable on current map. Spawned at random position: ({randomPos.X}, {randomPos.Y})"
+                );
             }
         }
     }

--- a/Server/Migrations/FractureDbContextModelSnapshot.cs
+++ b/Server/Migrations/FractureDbContextModelSnapshot.cs
@@ -114,6 +114,9 @@ namespace Fracture.Server.Migrations
                     b.Property<DateTime>("CreatedAt")
                         .HasColumnType("TEXT");
 
+                    b.Property<string>("PlayerPosition")
+                        .HasColumnType("TEXT");
+
                     b.Property<string>("Username")
                         .IsRequired()
                         .HasColumnType("TEXT");

--- a/Server/Modules/Database/IUsersRepository.cs
+++ b/Server/Modules/Database/IUsersRepository.cs
@@ -7,4 +7,5 @@ public interface IUsersRepository
     public Task<User> AddUserAsync(User user);
     public Task<User?> GetUserAsync(int id);
     public Task<User?> GetUserAsync(string username);
+    public Task SaveAsync();
 }

--- a/Server/Modules/Database/UsersRepository.cs
+++ b/Server/Modules/Database/UsersRepository.cs
@@ -38,4 +38,9 @@ public class UsersRepository : IUsersRepository
             .FirstOrDefaultAsync();
         return user;
     }
+
+    public async Task SaveAsync()
+    {
+        await _dbContext.SaveChangesAsync();
+    }
 }

--- a/Server/Modules/Users/Models/User.cs
+++ b/Server/Modules/Users/Models/User.cs
@@ -13,6 +13,11 @@ public class User
 
     public required string Username { get; set; }
 
+    /// <summary>
+    /// Pozycja gracza w formacie "X,Y"
+    /// </summary>
+    public string? PlayerPosition { get; set; }
+
     public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
 
     [InverseProperty(nameof(Item.CreatedBy))]

--- a/Server/Modules/Users/Services/MovementService.cs
+++ b/Server/Modules/Users/Services/MovementService.cs
@@ -35,8 +35,8 @@ public class MovementService
 
     public Map? CurrentMap { get; private set; }
 
-    public int CurrentX { get; private set; }
-    public int CurrentY { get; private set; }
+    public int CurrentX { get; set; }
+    public int CurrentY { get; set; }
 
     public event EventHandler<Position>? OnMoved;
     public event EventHandler<(Map, Position)>? OnMapEntered;
@@ -148,5 +148,11 @@ public class MovementService
             position.X,
             position.Y
         );
+    }
+
+    public async Task SavePlayerPositionAsync(int userId)
+    {
+        var position = $"{CurrentX},{CurrentY}";
+        await _userService.UpdatePlayerPositionAsync(userId, position);
     }
 }

--- a/Server/Modules/Users/Services/MovementService.cs
+++ b/Server/Modules/Users/Services/MovementService.cs
@@ -4,6 +4,7 @@ using Fracture.Server.Modules.Items.Models;
 using Fracture.Server.Modules.Items.Services;
 using Fracture.Server.Modules.MapGenerator.Models.Map;
 using Fracture.Server.Modules.MapGenerator.Services;
+using Microsoft.Extensions.Logging;
 
 namespace Fracture.Server.Modules.Users.Services;
 
@@ -14,16 +15,26 @@ public class MovementService
     private readonly IItemsRepository _itemsRepository;
     private readonly UserService _userService;
     private readonly ItemDropStateService _itemDropState;
+    private readonly IUsersRepository _usersRepository;
+    private readonly ILogger<MovementService> _logger;
 
     private Position? _pendingPickupPosition;
     private Item? _pendingPickupItem;
+
+    // Autosave fields
+    private CancellationTokenSource? _autosaveCts;
+    private int _lastSavedX;
+    private int _lastSavedY;
+    private const int AUTOSAVE_INTERVAL_MS = 120000; // 2 minuty
 
     public MovementService(
         MapManagerService mapManagerService,
         IItemGenerator itemGenerator,
         IItemsRepository itemsRepository,
         UserService userService,
-        ItemDropStateService itemDropState
+        ItemDropStateService itemDropState,
+        IUsersRepository usersRepository,
+        ILogger<MovementService> logger
     )
     {
         _mapManagerService = mapManagerService;
@@ -31,12 +42,14 @@ public class MovementService
         _itemsRepository = itemsRepository;
         _userService = userService;
         _itemDropState = itemDropState;
+        _usersRepository = usersRepository;
+        _logger = logger;
     }
 
     public Map? CurrentMap { get; private set; }
 
-    public int CurrentX { get; set; }
-    public int CurrentY { get; set; }
+    public int CurrentX { get; private set; }
+    public int CurrentY { get; private set; }
 
     public event EventHandler<Position>? OnMoved;
     public event EventHandler<(Map, Position)>? OnMapEntered;
@@ -49,16 +62,118 @@ public class MovementService
             _mapManagerService.GetWorldMap()
             ?? throw new InvalidOperationException("Map cannot be loaded, critical error");
 
-        var start = CurrentMap.GetRandomWalkableNode();
-        CurrentX = start.X;
-        CurrentY = start.Y;
+        // Wczytaj zapisaną pozycję gracza
+        await LoadPlayerPositionAsync();
 
-        if (_userService.User != null)
+        OnMapEntered?.Invoke(this, (CurrentMap, new Position(CurrentX, CurrentY)));
+
+        // Uruchom autosave automatycznie
+        StartAutosave();
+    }
+
+    /// <summary>
+    /// Wczytuje pozycję gracza z bazy danych
+    /// </summary>
+    public async Task LoadPlayerPositionAsync()
+    {
+        if (_userService.User?.PlayerPosition is null)
         {
-            await _itemDropState.EnsureLoadedAsync(_userService.User.Id);
+            // Jeśli nie ma zapisanej pozycji, ustaw pozycję startową
+            CurrentX = CurrentMap?.GetRandomWalkableNode().X ?? 0;
+            CurrentY = CurrentMap?.GetRandomWalkableNode().Y ?? 0;
+            return;
         }
 
-        OnMapEntered?.Invoke(this, new(CurrentMap, new Position(CurrentX, CurrentY)));
+        var parts = _userService.User.PlayerPosition.Split(',');
+        if (
+            parts.Length == 2
+            && int.TryParse(parts[0], out var x)
+            && int.TryParse(parts[1], out var y)
+        )
+        {
+            if (CanMove(x, y))
+            {
+                CurrentX = x;
+                CurrentY = y;
+                _lastSavedX = x;
+                _lastSavedY = y;
+                _logger.LogInformation($"Loaded player position: ({x}, {y})");
+            }
+            else
+            {
+                // Pozycja nie jest walkable - losuj nową
+                var randomPos = CurrentMap.GetRandomWalkableNode();
+                CurrentX = randomPos.X;
+                CurrentY = randomPos.Y;
+                _lastSavedX = randomPos.X;
+                _lastSavedY = randomPos.Y;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Zapisuje aktualną pozycję gracza do bazy danych
+    /// </summary>
+    public async Task SavePlayerPositionAsync()
+    {
+        if (_userService.User is null)
+            return;
+
+        _userService.User.PlayerPosition = $"{CurrentX},{CurrentY}";
+        await _usersRepository.SaveAsync();
+    }
+
+    /// <summary>
+    /// Uruchamia autosave pozycji gracza co 2 minuty
+    /// </summary>
+    public void StartAutosave()
+    {
+        _autosaveCts = new CancellationTokenSource();
+        _ = AutosavePositionAsync(_autosaveCts.Token);
+    }
+
+    /// <summary>
+    /// Zatrzymuje autosave
+    /// </summary>
+    public void StopAutosave()
+    {
+        _autosaveCts?.Cancel();
+        _autosaveCts?.Dispose();
+        _autosaveCts = null;
+    }
+
+    /// <summary>
+    /// Pętla autosave'a
+    /// </summary>
+    private async Task AutosavePositionAsync(CancellationToken cancellationToken)
+    {
+        while (!cancellationToken.IsCancellationRequested)
+        {
+            await Task.Delay(AUTOSAVE_INTERVAL_MS, cancellationToken);
+            if (CurrentX != _lastSavedX || CurrentY != _lastSavedY)
+            {
+                await SavePlayerPositionAsync();
+                _lastSavedX = CurrentX;
+                _lastSavedY = CurrentY;
+                _logger.LogInformation(
+                    $"Autosave triggered - position changed: ({_lastSavedX}, {_lastSavedY})"
+                );
+            }
+            else
+            {
+                _logger.LogInformation("Autosave skipped - position unchanged");
+            }
+        }
+    }
+
+    /// <summary>
+    /// Przeładowuje pozycję gracza (dla nowego użytkownika)
+    /// </summary>
+    public async Task ReloadPlayerPositionAsync()
+    {
+        _lastSavedX = CurrentX;
+        _lastSavedY = CurrentY;
+        await LoadPlayerPositionAsync();
     }
 
     public bool CanMove(int x, int y)
@@ -148,11 +263,5 @@ public class MovementService
             position.X,
             position.Y
         );
-    }
-
-    public async Task SavePlayerPositionAsync(int userId)
-    {
-        var position = $"{CurrentX},{CurrentY}";
-        await _userService.UpdatePlayerPositionAsync(userId, position);
     }
 }

--- a/Server/Modules/Users/Services/UserService.cs
+++ b/Server/Modules/Users/Services/UserService.cs
@@ -6,7 +6,7 @@ using static System.Reflection.Metadata.BlobBuilder;
 
 namespace Fracture.Server.Modules.Users.Services;
 
-public class UserService(IItemsRepository _itemsRepository)
+public class UserService(IItemsRepository _itemsRepository, IUsersRepository _usersRepository)
 {
     public User? User { get; private set; }
 
@@ -76,5 +76,21 @@ public class UserService(IItemsRepository _itemsRepository)
     public bool IsEquipped(Item item)
     {
         return Equipment.Contains(item);
+    }
+
+    public async Task UpdatePlayerPositionAsync(int userId, string position)
+    {
+        var user = await _usersRepository.GetUserAsync(userId); // ← zmienić z GetUserByIdAsync
+        if (user != null)
+        {
+            user.PlayerPosition = position;
+            await _usersRepository.SaveAsync();
+        }
+    }
+
+    public async Task<string?> GetPlayerPositionAsync(int userId)
+    {
+        var user = await _usersRepository.GetUserAsync(userId); // ← zmienić z GetUserByIdAsync
+        return user?.PlayerPosition;
     }
 }

--- a/Server/Modules/Users/Services/UserService.cs
+++ b/Server/Modules/Users/Services/UserService.cs
@@ -80,7 +80,7 @@ public class UserService(IItemsRepository _itemsRepository, IUsersRepository _us
 
     public async Task UpdatePlayerPositionAsync(int userId, string position)
     {
-        var user = await _usersRepository.GetUserAsync(userId); // ← zmienić z GetUserByIdAsync
+        var user = await _usersRepository.GetUserAsync(userId);
         if (user != null)
         {
             user.PlayerPosition = position;
@@ -90,7 +90,7 @@ public class UserService(IItemsRepository _itemsRepository, IUsersRepository _us
 
     public async Task<string?> GetPlayerPositionAsync(int userId)
     {
-        var user = await _usersRepository.GetUserAsync(userId); // ← zmienić z GetUserByIdAsync
+        var user = await _usersRepository.GetUserAsync(userId);
         return user?.PlayerPosition;
     }
 }


### PR DESCRIPTION
When player click on logout or shut down browser, his last location will be saved to DB, in addition each player's position saves every two minutes (this is protection against server shutdown). There is condition checking if player's position is on walkable node. (when map has changed, player won't be spawned on NonWalkable node)